### PR TITLE
Reduce the SchemaMessageValidatorMiddleware only to two mandatory checks: Source and CorrelationId

### DIFF
--- a/src/Messaging/NBB.Messaging.Host/MessagingPipeline/SchemaMessageValidatorMiddleware.cs
+++ b/src/Messaging/NBB.Messaging.Host/MessagingPipeline/SchemaMessageValidatorMiddleware.cs
@@ -19,17 +19,11 @@ namespace NBB.Messaging.Host
     {
         public async Task Invoke(MessagingContext context, CancellationToken cancellationToken, Func<Task> next)
         {
-            if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.MessageType, out var _))
-                throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.MessageType} header.");
-
             if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.CorrelationId, out var _))
                 throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.CorrelationId} header.");
 
-            if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.MessageId, out var _))
-                throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.MessageId} header.");
-
-            if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.PublishTime, out var _))
-                throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.PublishTime} header.");
+            if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.Source, out var _))
+                throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.Source} header.");
 
             await next();
         }

--- a/src/Messaging/NBB.Messaging.Host/MessagingPipeline/SchemaMessageValidatorMiddleware.cs
+++ b/src/Messaging/NBB.Messaging.Host/MessagingPipeline/SchemaMessageValidatorMiddleware.cs
@@ -31,9 +31,6 @@ namespace NBB.Messaging.Host
             if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.PublishTime, out var _))
                 throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.PublishTime} header.");
 
-            if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.StreamId, out var _))
-                throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.StreamId} header.");
-
             if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.Source, out var _))
                 throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.Source} header.");
 

--- a/src/Messaging/NBB.Messaging.Host/MessagingPipeline/SchemaMessageValidatorMiddleware.cs
+++ b/src/Messaging/NBB.Messaging.Host/MessagingPipeline/SchemaMessageValidatorMiddleware.cs
@@ -31,9 +31,6 @@ namespace NBB.Messaging.Host
             if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.PublishTime, out var _))
                 throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.PublishTime} header.");
 
-            if (!context.MessagingEnvelope.Headers.TryGetValue(MessagingHeaders.Source, out var _))
-                throw new Exception($"Message of type {context.MessagingEnvelope.Payload.GetType().GetPrettyName()} does not contain {MessagingHeaders.Source} header.");
-
             await next();
         }
     }


### PR DESCRIPTION
Reduce the SchemaMessageValidatorMiddleware only to two mandatory checks: Source and CorrelationId