### PR TITLE
support both single string and complex object connectionStrings 

### DIFF
--- a/src/MultiTenancy/NBB.MultiTenancy.Abstractions/Configuration/ITenantConfiguration.cs
+++ b/src/MultiTenancy/NBB.MultiTenancy.Abstractions/Configuration/ITenantConfiguration.cs
@@ -4,5 +4,12 @@
 namespace NBB.MultiTenancy.Abstractions.Configuration;
 public interface ITenantConfiguration
 {
+    /// <summary>
+    /// Extracts the value with the specified key and converts it to type T.
+    /// or
+    /// Attempts to bind the configuration instance to a new instance of type T.
+    /// If this configuration section has a value, that will be used.
+    /// Otherwise binding by matching property names against configuration keys recursively.
+    /// </summary>
     public T GetValue<T>(string key);
 }

--- a/src/MultiTenancy/NBB.MultiTenancy.Abstractions/Configuration/TenantConfigurationExtensions.cs
+++ b/src/MultiTenancy/NBB.MultiTenancy.Abstractions/Configuration/TenantConfigurationExtensions.cs
@@ -7,13 +7,28 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace NBB.MultiTenancy.Abstractions.Configuration
+namespace NBB.MultiTenancy.Abstractions.Configuration;
+
+public static class TenantConfigurationExtensions
 {
-    public static class TenantConfigurationExtensions
+    public static string GetConnectionString(this ITenantConfiguration config, string name)
     {
-        public static string GetConnectionString(this ITenantConfiguration config, string name)
+        var splitted = config.GetValue<ConnectionStringDetails>($"ConnectionStrings:{name}");
+        if (splitted != null)
         {
-            return config.GetValue<string>($"ConnectionStrings:{name}");
+            return
+                $"Server={splitted.Server};Database={splitted.Database};User Id={splitted.UserName};Password={splitted.Password};{splitted.OtherParams}";
         }
+
+        return config.GetValue<string>($"ConnectionStrings:{name}");
+    }
+
+    private class ConnectionStringDetails
+    {
+        public string Server { get; set; }
+        public string Database { get; set; }
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string OtherParams { get; set; }
     }
 }

--- a/test/UnitTests/MultiTenancy/NBB.MultiTenancy.Configuration.Tests/NBB.MultiTenancy.Configuration.Tests.csproj
+++ b/test/UnitTests/MultiTenancy/NBB.MultiTenancy.Configuration.Tests/NBB.MultiTenancy.Configuration.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsPackagesVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsPackagesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsPackagesVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />

--- a/test/UnitTests/MultiTenancy/NBB.MultiTenancy.Configuration.Tests/TenantConfigurationTests.cs
+++ b/test/UnitTests/MultiTenancy/NBB.MultiTenancy.Configuration.Tests/TenantConfigurationTests.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) TotalSoft.
 // This source code is licensed under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using Moq;
 using NBB.MultiTenancy.Abstractions;
 using NBB.MultiTenancy.Abstractions.Configuration;
 using NBB.MultiTenancy.Abstractions.Context;
 using NBB.MultiTenancy.Abstractions.Options;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Xunit;
 
 namespace NBB.MultiTenancy.Configuration.Tests
@@ -132,5 +133,350 @@ namespace NBB.MultiTenancy.Configuration.Tests
             tenantConfig.GetValue<string>("OtherProp2").Should().BeNull();
         }
 
+
+        [Fact]
+        public void load_connectionString_splitted_tenant1()
+        {
+            // Arrange
+            var myConfiguration = @"{
+                      ""MultiTenancy"": {
+                        ""Defaults"": {
+                          ""ConnectionStrings"": {
+                            ""Leasing_Database"": {
+                              ""Server"": ""cf-erp17"",
+                              ""Database"": ""db0"",
+                              ""UserName"": ""web"",
+                              ""Password"": ""mama123""
+                            }
+                          }
+                        },
+                        ""Tenants"": [
+                          {
+                            ""TenantId"": ""68a448a2-e7d8-4875-8127-f18668217eb6"",
+                            ""ConnectionStrings"": {
+                              ""Leasing_Database"": {
+                                ""Server"": ""server1"",
+                                ""Database"": ""db1"",
+                                ""UserName"": ""web"",
+                                ""OtherParams"": ""MultipleActiveResultSets=true""
+                              }
+                            }
+                          },
+                          {
+                            ""TenantId"": ""ef8d5362-9969-4e02-8794-0d1af56816f6"",
+                            ""Code"": ""BCR""
+                          },
+                          {
+                            ""TenantId"": ""da84628a-2925-4b69-9116-a90dd5a72b1f"",
+                            ""Code"": ""DEV""
+                          }
+                        ]
+                      }
+                    }";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(myConfiguration)))
+                .Build();
+
+            var tid = Guid.Parse("68a448a2-e7d8-4875-8127-f18668217eb6");
+            var tca = new TenantContextAccessor();
+
+            //arrange
+            tca.TenantContext = new TenantContext(new Tenant(tid, ""));
+            var tenantConfig = new TenantConfiguration(configuration,
+                new OptionsWrapper<TenancyHostingOptions>(new TenancyHostingOptions()
+                    { TenancyType = TenancyType.MultiTenant }), tca);
+
+
+            // Assert
+            tenantConfig.GetConnectionString("ConnectionString_").Should().BeNull();
+            tenantConfig.GetConnectionString("Leasing_Database").Should().Be("Server=server1;Database=db1;User Id=web;Password=;MultipleActiveResultSets=true");
+            tenantConfig.GetValue<string>("TenantId").Should().Be("68a448a2-e7d8-4875-8127-f18668217eb6");
+        }
+
+        [Fact]
+        public void load_connectionString_splitted_without_defaults()
+        {
+            // Arrange
+            var myConfiguration = @"{
+                      ""MultiTenancy"": {
+                        ""Defaults"": {
+                          ""ConnectionStrings"": { }
+                        },
+                        ""Tenants"": [
+                          {
+                            ""TenantId"": ""68a448a2-e7d8-4875-8127-f18668217eb6"",
+                            ""ConnectionStrings"": {
+                              ""Leasing_Database"": {
+                                ""Server"": ""server1"",
+                                ""Database"": ""db1"",
+                                ""UserName"": ""web"",
+                                ""OtherParams"": ""MultipleActiveResultSets=true""
+                              }
+                            }
+                          },
+                          {
+                            ""TenantId"": ""ef8d5362-9969-4e02-8794-0d1af56816f6"",
+                            ""Code"": ""BCR""
+                          },
+                          {
+                            ""TenantId"": ""da84628a-2925-4b69-9116-a90dd5a72b1f"",
+                            ""Code"": ""DEV""
+                          }
+                        ]
+                      }
+                    }";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(myConfiguration)))
+                .Build();
+
+            var tid = Guid.Parse("68a448a2-e7d8-4875-8127-f18668217eb6");
+            var tca = new TenantContextAccessor();
+
+            //arrange
+            tca.TenantContext = new TenantContext(new Tenant(tid, ""));
+            var tenantConfig = new TenantConfiguration(configuration,
+                new OptionsWrapper<TenancyHostingOptions>(new TenancyHostingOptions()
+                { TenancyType = TenancyType.MultiTenant }), tca);
+
+
+            // Assert
+            tenantConfig.GetConnectionString("ConnectionString_").Should().BeNull();
+            tenantConfig.GetConnectionString("Leasing_Database").Should().Be("Server=server1;Database=db1;User Id=web;Password=;MultipleActiveResultSets=true");
+            tenantConfig.GetValue<string>("TenantId").Should().Be("68a448a2-e7d8-4875-8127-f18668217eb6");
+        }
+
+
+        [Fact]
+        public void load_connectionString_splitted_from_default()
+        {
+            // Arrange
+            var myConfiguration = @"{
+                      ""MultiTenancy"": {
+                        ""Defaults"": {
+                          ""ConnectionStrings"": {
+                            ""Leasing_Database"": {
+                              ""Server"": ""cf-erp17\\mama"",
+                              ""Database"": ""db1"",
+                              ""UserName"": ""web""
+                            }
+                          }
+                        },
+                        ""Tenants"": [
+                          {
+                            ""TenantId"": ""68a448a2-e7d8-4875-8127-f18668217eb6"",
+                            ""ConnectionStrings"": {
+                              ""Leasing_Database"": {
+                                ""Server"": ""server1"",
+                                ""Database"": ""db1"",
+                                ""UserName"": ""web"",
+                                ""OtherParams"": ""MultipleActiveResultSets=true""
+                              }
+                            }
+                          },
+                          {
+                            ""TenantId"": ""ef8d5362-9969-4e02-8794-0d1af56816f6"",
+                            ""Code"": ""BCR""
+                          },
+                          {
+                            ""TenantId"": ""da84628a-2925-4b69-9116-a90dd5a72b1f"",
+                            ""Code"": ""DEV""
+                          }
+                        ]
+                      }
+                    }";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(myConfiguration)))
+                .Build();
+
+            var tid = Guid.Parse("ef8d5362-9969-4e02-8794-0d1af56816f6");
+            var tca = new TenantContextAccessor();
+
+            //arrange
+            tca.TenantContext = new TenantContext(new Tenant(tid, ""));
+            var tenantConfig = new TenantConfiguration(configuration,
+                new OptionsWrapper<TenancyHostingOptions>(new TenancyHostingOptions()
+                { TenancyType = TenancyType.MultiTenant }), tca);
+
+
+            // Assert
+            tenantConfig.GetConnectionString("ConnectionString_").Should().BeNull();
+            tenantConfig.GetConnectionString("Leasing_Database").Should().Be("Server=cf-erp17\\mama;Database=db1;User Id=web;Password=;");
+            tenantConfig.GetValue<string>("TenantId").Should().Be("ef8d5362-9969-4e02-8794-0d1af56816f6");
+        }
+
+        [Fact]
+        public void load_connectionString_concatenated_from_default()
+        {
+            // Arrange
+            var myConfiguration = @"{
+                      ""MultiTenancy"": {
+                        ""Defaults"": {
+                          ""ConnectionStrings"": {
+                            ""Leasing_Database"": ""Server=server0;Database=lsngdbqa;User Id=web;Password=pas;MultipleActiveResultSets=true""
+                          }
+                        },
+                        ""Tenants"": [
+                          {
+                            ""TenantId"": ""68a448a2-e7d8-4875-8127-f18668217eb6"",
+                            ""ConnectionStrings"": {
+                              ""Leasing_Database"": {
+                                ""Server"": ""server1"",
+                                ""Database"": ""db1"",
+                                ""UserName"": ""web"",
+                                ""OtherParams"": ""MultipleActiveResultSets=true""
+                              }
+                            }
+                          },
+                          {
+                            ""TenantId"": ""ef8d5362-9969-4e02-8794-0d1af56816f6"",
+                            ""Code"": ""BCR""
+                          },
+                          {
+                            ""TenantId"": ""da84628a-2925-4b69-9116-a90dd5a72b1f"",
+                            ""Code"": ""DEV""
+                          }
+                        ]
+                      }
+                    }";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(myConfiguration)))
+                .Build();
+
+            var tid = Guid.Parse("ef8d5362-9969-4e02-8794-0d1af56816f6");
+            var tca = new TenantContextAccessor();
+
+            //arrange
+            tca.TenantContext = new TenantContext(new Tenant(tid, ""));
+            var tenantConfig = new TenantConfiguration(configuration,
+                new OptionsWrapper<TenancyHostingOptions>(new TenancyHostingOptions()
+                { TenancyType = TenancyType.MultiTenant }), tca);
+
+
+            // Assert
+            tenantConfig.GetConnectionString("ConnectionString_").Should().BeNull();
+            tenantConfig.GetConnectionString("Leasing_Database").Should().Be("Server=server0;Database=lsngdbqa;User Id=web;Password=pas;MultipleActiveResultSets=true");
+            tenantConfig.GetValue<string>("TenantId").Should().Be("ef8d5362-9969-4e02-8794-0d1af56816f6");
+        }
+
+
+        [Fact]
+        public void load_connectionString_with_concatenated_defaults()
+        {
+            // Arrange
+            var myConfiguration = @"{
+                      ""MultiTenancy"": {
+                        ""Defaults"": {
+                          ""ConnectionStrings"": {
+                            ""Leasing_Database"": ""Server=server0;Database=lsngdbqa;User Id=web;Password=pas;MultipleActiveResultSets=true""
+                          }
+                        },
+                        ""Tenants"": [
+                          {
+                            ""TenantId"": ""68a448a2-e7d8-4875-8127-f18668217eb6"",
+                            ""ConnectionStrings"": {
+                              ""Leasing_Database"": {
+                                ""Server"": ""server1"",
+                                ""Database"": ""db1"",
+                                ""UserName"": ""web"",
+                                ""OtherParams"": ""MultipleActiveResultSets=true""
+                              }
+                            }
+                          },
+                          {
+                            ""TenantId"": ""ef8d5362-9969-4e02-8794-0d1af56816f6"",
+                            ""Code"": ""BCR""
+                          },
+                          {
+                            ""TenantId"": ""da84628a-2925-4b69-9116-a90dd5a72b1f"",
+                            ""Code"": ""DEV""
+                          }
+                        ]
+                      }
+                    }";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(myConfiguration)))
+                .Build();
+
+            var tid = Guid.Parse("68a448a2-e7d8-4875-8127-f18668217eb6");
+            var tca = new TenantContextAccessor();
+
+            //arrange
+            tca.TenantContext = new TenantContext(new Tenant(tid, ""));
+            var tenantConfig = new TenantConfiguration(configuration,
+                new OptionsWrapper<TenancyHostingOptions>(new TenancyHostingOptions()
+                { TenancyType = TenancyType.MultiTenant }), tca);
+
+
+            // Assert
+            tenantConfig.GetConnectionString("ConnectionString_").Should().BeNull();
+            tenantConfig.GetConnectionString("Leasing_Database").Should().Be("Server=server1;Database=db1;User Id=web;Password=;MultipleActiveResultSets=true");
+            tenantConfig.GetValue<string>("TenantId").Should().Be("68a448a2-e7d8-4875-8127-f18668217eb6");
+        }
+
+        [Fact]
+        public void load_connectionString_concatenated_with_splitted_defaults()
+        {
+            // Arrange
+            var myConfiguration = @"{
+                      ""MultiTenancy"": {
+                        ""Defaults"": {
+                          ""ConnectionStrings"": {
+                              ""Leasing_Database"": {
+                                ""Server"": ""server1"",
+                                ""Database"": ""db1"",
+                                ""UserName"": ""web"",
+                                ""OtherParams"": ""MultipleActiveResultSets=true""
+                              }
+                          }
+                        },
+                        ""Tenants"": [
+                          {
+                            ""TenantId"": ""68a448a2-e7d8-4875-8127-f18668217eb6"",
+                            ""ConnectionStrings"": {
+                              ""Leasing_Database"": ""Server=server0;Database=lsngdbqa;User Id=web;Password=B1llpwd!;MultipleActiveResultSets=true""
+                            }
+                          },
+                          {
+                            ""TenantId"": ""ef8d5362-9969-4e02-8794-0d1af56816f6"",
+                            ""Code"": ""BCR""
+                          },
+                          {
+                            ""TenantId"": ""da84628a-2925-4b69-9116-a90dd5a72b1f"",
+                            ""Code"": ""DEV""
+                          }
+                        ]
+                      }
+                    }";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(myConfiguration)))
+                .Build();
+
+            var tid = Guid.Parse("68a448a2-e7d8-4875-8127-f18668217eb6");
+            var tca = new TenantContextAccessor();
+
+            //arrange
+            tca.TenantContext = new TenantContext(new Tenant(tid, ""));
+            var tenantConfig = new TenantConfiguration(configuration,
+                new OptionsWrapper<TenancyHostingOptions>(new TenancyHostingOptions()
+                { TenancyType = TenancyType.MultiTenant }), tca);
+
+
+            // Assert
+            tenantConfig.GetConnectionString("ConnectionString_").Should().BeNull();
+            tenantConfig.GetConnectionString("Leasing_Database").Should().Be("Server=server0;Database=lsngdbqa;User Id=web;Password=B1llpwd!;MultipleActiveResultSets=true");
+            tenantConfig.GetValue<string>("TenantId").Should().Be("68a448a2-e7d8-4875-8127-f18668217eb6");
+        }
     }
 }


### PR DESCRIPTION
change configuration source, to support both single string and complex object connectionStrings 

```json
  "ConnectionStrings": {
          "Leasing_Database": {
            "Server": "server",
            "Database": "db",
            "UserName": "user",
            "Password": "pass"
          }
        }
```