### PR TITLE
Fixed process crash on message handler

### DIFF
--- a/src/Messaging/NBB.Messaging.Nats/StanMessagingTransport.cs
+++ b/src/Messaging/NBB.Messaging.Nats/StanMessagingTransport.cs
@@ -44,18 +44,15 @@ namespace NBB.Messaging.Nats
             opts.AckWait = subscriberOptions.AckWait ?? _natsOptions.Value.AckWait ?? 50000;
             opts.ManualAcks = true;
 
-            //CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            
-            async void StanMsgHandler(object obj, StanMsgHandlerArgs args)
+            void StanMsgHandler(object obj, StanMsgHandlerArgs args)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return;
 
                 var receiveContext = new TransportReceiveContext(new TransportReceivedData.EnvelopeBytes(args.Message.Data));
 
-                await handler(receiveContext);
-                
-                args.Message.Ack();
+                // Fire and forget
+                _ = handler(receiveContext).ContinueWith(_ => args.Message.Ack(), cancellationToken);
             }
 
             IDisposable subscription = null;


### PR DESCRIPTION
The process crashes when publishing to the dead letter queue, usually when a publish decorator throws an exception. It only crashes when the code that throws the error is executed synchronously (without/before calling await).

The issue was caused because an exception was thrown in an "async void" method in the nats transport implementation. For details see [this link](https://stackoverflow.com/questions/53215577/why-does-exception-from-async-void-crash-the-app-but-from-async-task-is-swallowe)

The fix was to replace the "async void" method with Task fire and forget.
Other changes:
* more robust error handling when pushing to DLQ
* force the message bus publishing in DLQ to execute asynchronously(non- blocking)