### PR TITLE
fix rusi unsubscribe

### DIFF
--- a/NBB.sln
+++ b/NBB.sln
@@ -398,9 +398,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Serilog", "Serilog", "{33AE
 		src\Tools\Serilog\README.md = src\Tools\Serilog\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBB.Core.Configuration", "src\Core\NBB.Core.Configuration\NBB.Core.Configuration.csproj", "{2C7CA0BD-98AD-4CC1-B496-94ED49636466}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NBB.Core.Configuration", "src\Core\NBB.Core.Configuration\NBB.Core.Configuration.csproj", "{2C7CA0BD-98AD-4CC1-B496-94ED49636466}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBB.Core.Configuration.Tests", "test\UnitTests\Core\NBB.Core.Configuration.Tests\NBB.Core.Configuration.Tests.csproj", "{2A91E54D-F63C-4E92-9A6D-F15C7C55B0D7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NBB.Core.Configuration.Tests", "test\UnitTests\Core\NBB.Core.Configuration.Tests\NBB.Core.Configuration.Tests.csproj", "{2A91E54D-F63C-4E92-9A6D-F15C7C55B0D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBB.Messaging.Rusi.IntegrationTests", "test\Integration\NBB.Messaging.Rusi.IntegrationTests\NBB.Messaging.Rusi.IntegrationTests.csproj", "{2D002428-8D55-46BD-A588-84946E33B4EF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -904,6 +906,10 @@ Global
 		{2A91E54D-F63C-4E92-9A6D-F15C7C55B0D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A91E54D-F63C-4E92-9A6D-F15C7C55B0D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A91E54D-F63C-4E92-9A6D-F15C7C55B0D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D002428-8D55-46BD-A588-84946E33B4EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D002428-8D55-46BD-A588-84946E33B4EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D002428-8D55-46BD-A588-84946E33B4EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D002428-8D55-46BD-A588-84946E33B4EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1071,6 +1077,7 @@ Global
 		{33AEB049-EC66-4728-9B22-CC0F282D3E73} = {EF374BA2-61FC-41FB-8229-5187DCBAA63A}
 		{2C7CA0BD-98AD-4CC1-B496-94ED49636466} = {14726095-DA28-43A6-A9A9-F16C605932E1}
 		{2A91E54D-F63C-4E92-9A6D-F15C7C55B0D7} = {29B7593C-60F4-41DC-A883-4976FF467927}
+		{2D002428-8D55-46BD-A588-84946E33B4EF} = {2D9089E7-54EA-4526-B8FE-12729BF14F16}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {23A42379-616A-43EF-99BC-803DF151F54E}

--- a/src/Messaging/NBB.Messaging.Rusi/RusiMessagingTransport.cs
+++ b/src/Messaging/NBB.Messaging.Rusi/RusiMessagingTransport.cs
@@ -131,20 +131,7 @@ namespace NBB.Messaging.Rusi
                 }
             }, cancellationToken);
 
-            return Task.FromResult<IDisposable>(new RusiSubscription(subscription));
-        }
-    }
-
-    internal class RusiSubscription : IDisposable
-    {
-        private readonly AsyncDuplexStreamingCall<SubscribeRequest, ReceivedMessage> _call;
-
-        public RusiSubscription(AsyncDuplexStreamingCall<SubscribeRequest, ReceivedMessage> call) => _call = call;
-
-        public void Dispose()
-        {
-            _call.RequestStream.CompleteAsync().GetAwaiter().GetResult(); //block since the api does not support IAsyncDisposable
-            _call.Dispose();
+            return subscription;
         }
     }
 }

--- a/test/Integration/NBB.Messaging.Rusi.IntegrationTests/NBB.Messaging.Rusi.IntegrationTests.csproj
+++ b/test/Integration/NBB.Messaging.Rusi.IntegrationTests/NBB.Messaging.Rusi.IntegrationTests.csproj
@@ -1,0 +1,48 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsPackagesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsPackagesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="$(MicrosoftExtensionsPackagesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsPackagesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsPackagesVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackagesVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkPackageVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioPackageVersion)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Messaging\NBB.Messaging.Rusi\NBB.Messaging.Rusi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Integration/NBB.Messaging.Rusi.IntegrationTests/RusiTransportTests.cs
+++ b/test/Integration/NBB.Messaging.Rusi.IntegrationTests/RusiTransportTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NBB.Messaging.Abstractions;
+
+namespace NBB.Messaging.Rusi.IntegrationTests
+{
+    public class RusiTransportTests
+    {
+        //[Fact]
+        public async Task Test_unsubscribe_with_dispose()
+        {
+            var sp = BuildServiceProvider();
+            var msgBus = sp.GetRequiredService<IMessageBus>();
+            var sub = await msgBus.SubscribeAsync(_e => Task.CompletedTask, MessagingSubscriberOptions.Default with { TopicName = "MyTestTopic", Transport = SubscriptionTransportOptions.RequestReply });
+            sub.Dispose();
+        }
+
+        //[Fact]
+        public async Task Test_unsubscribe_with_cancel_and_dispose()
+        {
+            var sp = BuildServiceProvider();
+            var msgBus = sp.GetRequiredService<IMessageBus>();
+            var cts = new CancellationTokenSource();
+            var sub = await msgBus.SubscribeAsync(_e => Task.CompletedTask, MessagingSubscriberOptions.Default with { TopicName = "MyTestTopic", Transport = SubscriptionTransportOptions.RequestReply }, cts.Token);
+            cts.Cancel();
+            sub.Dispose();
+        }
+
+        private IServiceProvider BuildServiceProvider()
+        {
+            var services = new ServiceCollection();
+            var configurationBuilder = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddEnvironmentVariables();
+            var configuration = configurationBuilder.Build();
+            services.AddSingleton<IConfiguration>(configuration);
+            services.AddLogging();
+            services.AddMessageBus().AddRusiTransport(configuration);
+
+            return services.BuildServiceProvider();
+
+        }
+    }
+}

--- a/test/Integration/NBB.Messaging.Rusi.IntegrationTests/Usings.cs
+++ b/test/Integration/NBB.Messaging.Rusi.IntegrationTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/Integration/NBB.Messaging.Rusi.IntegrationTests/appsettings.json
+++ b/test/Integration/NBB.Messaging.Rusi.IntegrationTests/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+    "Messaging": {
+        "Source": "NBB.Messaging.Rusi.IntegrationTests",
+        "Rusi": {
+            "RusiPort": 50003
+        }
+    }
+}


### PR DESCRIPTION
 - the problem was that RusiMessagingTransport.SubscribeAsync returned a Task.FromResult(subscription) instead of returning the subscription. The Task is also IDisposable so the bug was not cought by the compiler. So the subscription itself was never disposed.
 - I have removed the RusiSubscription wrapper since the disposal of AsyncDuplexStreamingCall is sufficient