### PR TITLE
msg host config builder - re-use pipeline 4 more subscriber groups

### DIFF
--- a/src/Messaging/NBB.Messaging.Host/Builder/MessagingHostConfigurationBuilder.cs
+++ b/src/Messaging/NBB.Messaging.Host/Builder/MessagingHostConfigurationBuilder.cs
@@ -38,8 +38,11 @@ namespace NBB.Messaging.Host
             _messageTypeProvider = subscriberServiceSelector;
             _topicProvider = subscriberServiceSelector;
 
-            _currentSubscriberGroup = new List<MessagingHostConfiguration.Subscriber>();
-             _subscriberGroups.Add(_currentSubscriberGroup);
+            if (_currentSubscriberGroup == null)
+            {
+                _currentSubscriberGroup = new List<MessagingHostConfiguration.Subscriber>();
+                _subscriberGroups.Add(_currentSubscriberGroup);
+            }
 
             return this;
         }
@@ -143,7 +146,7 @@ namespace NBB.Messaging.Host
     /// <summary>
     /// Used to subscriberBuilder the messaging host pipeline
     /// </summary>
-    public interface IMessagingHostPipelineBuilder
+    public interface IMessagingHostPipelineBuilder : IMessagingHostConfigurationBuilder
     {
         /// <summary>
         /// Adds the message processing pipeline to the messaging host.

--- a/src/Messaging/NBB.Messaging.Host/README.md
+++ b/src/Messaging/NBB.Messaging.Host/README.md
@@ -73,7 +73,28 @@ services.AddMessagingHost(
         );
     }
 );
-```      
+```
+
+#### Multiple subscriber groups using the same pipeline
+
+In case you need to use the same pipeline for more subscriber groups, the builder lets you chain multiple `AddSubscriberServices(...).WithOptions(...)` function calls:
+
+```csharp
+
+services.AddMessagingHost(
+    Configuration,
+    hostBuilder =>
+    {
+        hostBuilder.Configure(configBuilder => configBuilder
+            .AddSubscriberServices(...)
+            .WithOptions(...)
+            .AddSubscriberServices(...)
+            .WithOptions(...)
+            .UsePipeline(...)
+        );
+    }
+);
+``` 
 
 #### Advanced scenarios
 There is an overload of the *Configure* method that allows async/await operations.


### PR DESCRIPTION
One should be able to configure multiple subscriber groups using the same pipeline:
```csharp
builder
    .AddSubscriberServices(...).WithOptions(...)
    .AddSubscriberServices(...).WithOptions(...)
    .UsePipeline(...);
```